### PR TITLE
Add a new api settings_dirs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{md,markdown}]
+insert_final_newline = false
+trim_trailing_whitespace = false
+
+[*.{rs}]
+indent_size = 4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "dirs"
-version     = "3.0.2"
+version     = "3.1.0"
 authors     = ["Simon Ochsenreither <simon@ochsenreither.de>"]
 description = "A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows, macOS and Redox by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS."
 readme      = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# `fuyutarow/dirs` vs `dirs`
+
+fuyutarow/dirs has added a new api settings_dir.
+
+On mac, $HOME/.config is used by many applications (yarn, neovim, etc.) and is also a value used by gtk applications. [[ref](https://wiki.gnucash.org/wiki/Configuration_Locations#USER_CONFIG_HOME)]
+
+| Function name    | Value on Linux/Redox                                                                             | Value on Windows                  | Value on macOS                              |
+| ---------------- | ------------------------------------------------------------------------------------------------ | --------------------------------- | ------------------------------------------- |
+| `settings_dir`   | `Some($XDG_CONFIG_HOME)`        or `Some($HOME`/.config`)`                                       | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/.config`)`                     |
+
+
+
+* * *
+
+
 [![crates.io](https://img.shields.io/crates/v/dirs.svg)](https://crates.io/crates/dirs)
 [![API documentation](https://docs.rs/dirs/badge.svg)](https://docs.rs/dirs/)
 ![actively developed](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
@@ -109,6 +124,7 @@ use `ProjectDirs` of the [directories](https://github.com/dirs-dev/directories-r
 | `home_dir`       | `Some($HOME)`                                                                                    | `Some({FOLDERID_Profile})`        | `Some($HOME)`                               |
 | `cache_dir`      | `Some($XDG_CACHE_HOME)`         or `Some($HOME`/.cache`)`                                        | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Caches`)`              |
 | `config_dir`     | `Some($XDG_CONFIG_HOME)`        or `Some($HOME`/.config`)`                                       | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Application Support`)` |
+| `settings_dir`   | `Some($XDG_CONFIG_HOME)`        or `Some($HOME`/.config`)`                                       | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/.config`)`                     |
 | `data_dir`       | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`                                  | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Application Support`)` |
 | `data_local_dir` | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`                                  | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Application Support`)` |
 | `executable_dir` | `Some($XDG_BIN_HOME`/../bin`)`  or `Some($XDG_DATA_HOME`/../bin`)` or `Some($HOME`/.local/bin`)` | `None`                            | `None`                                      |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ mod tests {
         println!("audio_dir:      {:?}", ::audio_dir());
         println!("home_dir:       {:?}", ::desktop_dir());
         println!("cache_dir:      {:?}", ::document_dir());
-        println!("config_dir:     {:?}", ::download_dir());
+        println!("download_dir:   {:?}", ::download_dir());
         println!("font_dir:       {:?}", ::font_dir());
         println!("picture_dir:    {:?}", ::picture_dir());
         println!("public_dir:     {:?}", ::public_dir());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,13 +32,15 @@ use wasm as sys;
 
 #[cfg(not(any(
     target_os = "windows",
-    target_os = "macos", target_os = "ios",
+    target_os = "macos",
+    target_os = "ios",
     target_arch = "wasm32"
 )))]
 mod lin;
 #[cfg(not(any(
     target_os = "windows",
-    target_os = "macos", target_os = "ios",
+    target_os = "macos",
+    target_os = "ios",
     target_arch = "wasm32"
 )))]
 use lin as sys;
@@ -97,6 +99,18 @@ pub fn cache_dir() -> Option<PathBuf> {
 /// | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming           |
 pub fn config_dir() -> Option<PathBuf> {
     sys::config_dir()
+}
+/// Returns the path to the user's settings directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
+///
+/// |Platform | Value                                 | Example                                  |
+/// | ------- | ------------------------------------- | ---------------------------------------- |
+/// | Linux   | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config                      |
+/// | macOS   | `$HOME`/.config                       | /Users/Alice/Library/Application Support |
+/// | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming           |
+pub fn settings_dir() -> Option<PathBuf> {
+    sys::settings_dir()
 }
 /// Returns the path to the user's data directory.
 ///
@@ -276,6 +290,7 @@ mod tests {
         println!("home_dir:       {:?}", ::home_dir());
         println!("cache_dir:      {:?}", ::cache_dir());
         println!("config_dir:     {:?}", ::config_dir());
+        println!("settings_dir:   {:?}", ::settings_dir());
         println!("data_dir:       {:?}", ::data_dir());
         println!("data_local_dir: {:?}", ::data_local_dir());
         println!("executable_dir: {:?}", ::executable_dir());

--- a/src/lin.rs
+++ b/src/lin.rs
@@ -3,27 +3,74 @@ extern crate dirs_sys;
 use std::env;
 use std::path::PathBuf;
 
-pub fn home_dir()       -> Option<PathBuf> { dirs_sys::home_dir() }
-pub fn cache_dir()      -> Option<PathBuf> { env::var_os("XDG_CACHE_HOME") .and_then(dirs_sys::is_absolute_path).or_else(|| home_dir().map(|h| h.join(".cache"))) }
-pub fn config_dir()     -> Option<PathBuf> { env::var_os("XDG_CONFIG_HOME").and_then(dirs_sys::is_absolute_path).or_else(|| home_dir().map(|h| h.join(".config"))) }
-pub fn data_dir()       -> Option<PathBuf> { env::var_os("XDG_DATA_HOME")  .and_then(dirs_sys::is_absolute_path).or_else(|| home_dir().map(|h| h.join(".local/share"))) }
-pub fn data_local_dir() -> Option<PathBuf> { data_dir() }
-pub fn preference_dir() -> Option<PathBuf> { config_dir() }
-pub fn runtime_dir()    -> Option<PathBuf> { env::var_os("XDG_RUNTIME_DIR").and_then(dirs_sys::is_absolute_path) }
-pub fn executable_dir() -> Option<PathBuf> {
-    env::var_os("XDG_BIN_HOME").and_then(dirs_sys::is_absolute_path).or_else(|| {
-        data_dir().map(|mut e| { e.pop(); e.push("bin"); e })
-    })
+pub fn home_dir() -> Option<PathBuf> {
+    dirs_sys::home_dir()
 }
-pub fn audio_dir()      -> Option<PathBuf> { dirs_sys::user_dir("MUSIC") }
-pub fn desktop_dir()    -> Option<PathBuf> { dirs_sys::user_dir("DESKTOP") }
-pub fn document_dir()   -> Option<PathBuf> { dirs_sys::user_dir("DOCUMENTS") }
-pub fn download_dir()   -> Option<PathBuf> { dirs_sys::user_dir("DOWNLOAD") }
-pub fn font_dir()       -> Option<PathBuf> { data_dir().map(|d| d.join("fonts")) }
-pub fn picture_dir()    -> Option<PathBuf> { dirs_sys::user_dir("PICTURES") }
-pub fn public_dir()     -> Option<PathBuf> { dirs_sys::user_dir("PUBLICSHARE") }
-pub fn template_dir()   -> Option<PathBuf> { dirs_sys::user_dir("TEMPLATES") }
-pub fn video_dir()      -> Option<PathBuf> { dirs_sys::user_dir("VIDEOS") }
+pub fn cache_dir() -> Option<PathBuf> {
+    env::var_os("XDG_CACHE_HOME")
+        .and_then(dirs_sys::is_absolute_path)
+        .or_else(|| home_dir().map(|h| h.join(".cache")))
+}
+pub fn config_dir() -> Option<PathBuf> {
+    env::var_os("XDG_CONFIG_HOME")
+        .and_then(dirs_sys::is_absolute_path)
+        .or_else(|| home_dir().map(|h| h.join(".config")))
+}
+pub fn settings_dir() -> Option<PathBuf> {
+    config_dir()
+}
+pub fn data_dir() -> Option<PathBuf> {
+    env::var_os("XDG_DATA_HOME")
+        .and_then(dirs_sys::is_absolute_path)
+        .or_else(|| home_dir().map(|h| h.join(".local/share")))
+}
+pub fn data_local_dir() -> Option<PathBuf> {
+    data_dir()
+}
+pub fn preference_dir() -> Option<PathBuf> {
+    config_dir()
+}
+pub fn runtime_dir() -> Option<PathBuf> {
+    env::var_os("XDG_RUNTIME_DIR").and_then(dirs_sys::is_absolute_path)
+}
+pub fn executable_dir() -> Option<PathBuf> {
+    env::var_os("XDG_BIN_HOME")
+        .and_then(dirs_sys::is_absolute_path)
+        .or_else(|| {
+            data_dir().map(|mut e| {
+                e.pop();
+                e.push("bin");
+                e
+            })
+        })
+}
+pub fn audio_dir() -> Option<PathBuf> {
+    dirs_sys::user_dir("MUSIC")
+}
+pub fn desktop_dir() -> Option<PathBuf> {
+    dirs_sys::user_dir("DESKTOP")
+}
+pub fn document_dir() -> Option<PathBuf> {
+    dirs_sys::user_dir("DOCUMENTS")
+}
+pub fn download_dir() -> Option<PathBuf> {
+    dirs_sys::user_dir("DOWNLOAD")
+}
+pub fn font_dir() -> Option<PathBuf> {
+    data_dir().map(|d| d.join("fonts"))
+}
+pub fn picture_dir() -> Option<PathBuf> {
+    dirs_sys::user_dir("PICTURES")
+}
+pub fn public_dir() -> Option<PathBuf> {
+    dirs_sys::user_dir("PUBLICSHARE")
+}
+pub fn template_dir() -> Option<PathBuf> {
+    dirs_sys::user_dir("TEMPLATES")
+}
+pub fn video_dir() -> Option<PathBuf> {
+    dirs_sys::user_dir("VIDEOS")
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -2,20 +2,57 @@ extern crate dirs_sys;
 
 use std::path::PathBuf;
 
-pub fn home_dir()       -> Option<PathBuf> { dirs_sys::home_dir() }
-pub fn cache_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Caches")) }
-pub fn config_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Application Support")) }
-pub fn data_dir()       -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Application Support")) }
-pub fn data_local_dir() -> Option<PathBuf> { data_dir() }
-pub fn preference_dir() -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Preferences")) }
-pub fn executable_dir() -> Option<PathBuf> { None }
-pub fn runtime_dir()    -> Option<PathBuf> { None }
-pub fn audio_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Music")) }
-pub fn desktop_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Desktop")) }
-pub fn document_dir()   -> Option<PathBuf> { home_dir().map(|h| h.join("Documents")) }
-pub fn download_dir()   -> Option<PathBuf> { home_dir().map(|h| h.join("Downloads")) }
-pub fn font_dir()       -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Fonts")) }
-pub fn picture_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Pictures")) }
-pub fn public_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Public")) }
-pub fn template_dir()   -> Option<PathBuf> { None }
-pub fn video_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Movies")) }
+pub fn home_dir() -> Option<PathBuf> {
+    dirs_sys::home_dir()
+}
+pub fn cache_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Library/Caches"))
+}
+pub fn config_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Library/Application Support"))
+}
+pub fn settings_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join(".config"))
+}
+pub fn data_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Library/Application Support"))
+}
+pub fn data_local_dir() -> Option<PathBuf> {
+    data_dir()
+}
+pub fn preference_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Library/Preferences"))
+}
+pub fn executable_dir() -> Option<PathBuf> {
+    None
+}
+pub fn runtime_dir() -> Option<PathBuf> {
+    None
+}
+pub fn audio_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Music"))
+}
+pub fn desktop_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Desktop"))
+}
+pub fn document_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Documents"))
+}
+pub fn download_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Downloads"))
+}
+pub fn font_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Library/Fonts"))
+}
+pub fn picture_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Pictures"))
+}
+pub fn public_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Public"))
+}
+pub fn template_dir() -> Option<PathBuf> {
+    None
+}
+pub fn video_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Movies"))
+}

--- a/src/win.rs
+++ b/src/win.rs
@@ -2,20 +2,57 @@ extern crate dirs_sys;
 
 use std::path::PathBuf;
 
-pub fn home_dir()       -> Option<PathBuf> { dirs_sys::known_folder_profile() }
-pub fn data_dir()       -> Option<PathBuf> { dirs_sys::known_folder_roaming_app_data() }
-pub fn data_local_dir() -> Option<PathBuf> { dirs_sys::known_folder_local_app_data() }
-pub fn cache_dir()      -> Option<PathBuf> { data_local_dir() }
-pub fn config_dir()     -> Option<PathBuf> { data_dir() }
-pub fn executable_dir() -> Option<PathBuf> { None }
-pub fn preference_dir() -> Option<PathBuf> { data_dir() }
-pub fn runtime_dir()    -> Option<PathBuf> { None }
-pub fn audio_dir()      -> Option<PathBuf> { dirs_sys::known_folder_music() }
-pub fn desktop_dir()    -> Option<PathBuf> { dirs_sys::known_folder_desktop() }
-pub fn document_dir()   -> Option<PathBuf> { dirs_sys::known_folder_documents() }
-pub fn download_dir()   -> Option<PathBuf> { dirs_sys::known_folder_downloads() }
-pub fn font_dir()       -> Option<PathBuf> { None }
-pub fn picture_dir()    -> Option<PathBuf> { dirs_sys::known_folder_pictures() }
-pub fn public_dir()     -> Option<PathBuf> { dirs_sys::known_folder_public()}
-pub fn template_dir()   -> Option<PathBuf> { dirs_sys::known_folder_templates() }
-pub fn video_dir()      -> Option<PathBuf> { dirs_sys::known_folder_videos() }
+pub fn home_dir() -> Option<PathBuf> {
+    dirs_sys::known_folder_profile()
+}
+pub fn data_dir() -> Option<PathBuf> {
+    dirs_sys::known_folder_roaming_app_data()
+}
+pub fn data_local_dir() -> Option<PathBuf> {
+    dirs_sys::known_folder_local_app_data()
+}
+pub fn cache_dir() -> Option<PathBuf> {
+    data_local_dir()
+}
+pub fn config_dir() -> Option<PathBuf> {
+    data_dir()
+}
+pub fn settings_dir() -> Option<PathBuf> {
+    data_dir()
+}
+pub fn executable_dir() -> Option<PathBuf> {
+    None
+}
+pub fn preference_dir() -> Option<PathBuf> {
+    data_dir()
+}
+pub fn runtime_dir() -> Option<PathBuf> {
+    None
+}
+pub fn audio_dir() -> Option<PathBuf> {
+    dirs_sys::known_folder_music()
+}
+pub fn desktop_dir() -> Option<PathBuf> {
+    dirs_sys::known_folder_desktop()
+}
+pub fn document_dir() -> Option<PathBuf> {
+    dirs_sys::known_folder_documents()
+}
+pub fn download_dir() -> Option<PathBuf> {
+    dirs_sys::known_folder_downloads()
+}
+pub fn font_dir() -> Option<PathBuf> {
+    None
+}
+pub fn picture_dir() -> Option<PathBuf> {
+    dirs_sys::known_folder_pictures()
+}
+pub fn public_dir() -> Option<PathBuf> {
+    dirs_sys::known_folder_public()
+}
+pub fn template_dir() -> Option<PathBuf> {
+    dirs_sys::known_folder_templates()
+}
+pub fn video_dir() -> Option<PathBuf> {
+    dirs_sys::known_folder_videos()
+}


### PR DESCRIPTION
On mac, $HOME/.config is used by many applications (yarn, neovim, etc.) and is also a value used by gtk applications. [[ref](https://wiki.gnucash.org/wiki/Configuration_Locations#USER_CONFIG_HOME)]